### PR TITLE
fix(deprecated): remove use of deprecated reflect functions

### DIFF
--- a/js.go
+++ b/js.go
@@ -116,11 +116,9 @@ func IsEqual(l, r interface{}) bool {
 		rptr := reflect.ValueOf(rmap)
 		return lptr == rptr
 	case lisslice && risslice:
-		lhdr := (*reflect.SliceHeader)(unsafe.Pointer(&lslice))
-		rhdr := (*reflect.SliceHeader)(unsafe.Pointer(&rslice))
-		return lhdr.Cap == rhdr.Cap &&
-			lhdr.Len == rhdr.Len &&
-			lhdr.Data == rhdr.Data
+		return cap(lslice) == cap(rslice) &&
+			len(lslice) == len(rslice) &&
+			unsafe.SliceData(lslice) == unsafe.SliceData(rslice)
 	case
 		lisbool && risbool,
 		lisfloat && risfloat,
@@ -157,11 +155,9 @@ func IsSoftEqual(l, r interface{}) bool {
 		rptr := reflect.ValueOf(rmap)
 		return lptr == rptr
 	case lisslice && risslice:
-		lhdr := (*reflect.SliceHeader)(unsafe.Pointer(&lslice))
-		rhdr := (*reflect.SliceHeader)(unsafe.Pointer(&rslice))
-		return lhdr.Cap == rhdr.Cap &&
-			lhdr.Len == rhdr.Len &&
-			lhdr.Data == rhdr.Data
+		return cap(lslice) == cap(rslice) &&
+			len(lslice) == len(rslice) &&
+			unsafe.SliceData(lslice) == unsafe.SliceData(rslice)
 	case lisslice || risslice:
 		if lisslice {
 			return IsSoftEqual(toString(l), r)


### PR DESCRIPTION
No discernable change in behaviour

goos: linux
goarch: amd64
pkg: github.com/tcolgate/jsonlogic
cpu: 13th Gen Intel(R) Core(TM) i7-13700H
                    │   old.txt    │               new.txt               │
                    │    sec/op    │    sec/op     vs base               │
FizzBuzz-20           293.4n ±  6%   280.2n ±  5%       ~ (p=0.305 n=10)
In-20                 24.73n ±  4%   23.29n ±  2%  -5.80% (p=0.000 n=10)
Clause_testsuite-20   32.35µ ± 11%   33.85µ ± 12%       ~ (p=0.853 n=10)
geomean               616.8n         604.6n        -1.98%

                    │    old.txt     │                new.txt                │
                    │      B/op      │     B/op      vs base                 │
FizzBuzz-20             64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=10) ¹
In-20                   0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Clause_testsuite-20   13.24Ki ± 0%     13.24Ki ± 0%       ~ (p=0.342 n=10)
geomean                            ²                 -0.01%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                    │   old.txt    │               new.txt               │
                    │  allocs/op   │ allocs/op   vs base                 │
FizzBuzz-20           5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
In-20                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Clause_testsuite-20   457.0 ± 0%     457.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                          ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean